### PR TITLE
Remove Kudos Warning

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines.md
@@ -122,14 +122,6 @@ Use the [OARS website](https://hughsie.github.io/oars/generate.html) to generate
 <content_rating type="oars-1.1" />
 ```
 
-:::note
-
-For some of these, e.g. the above-mentioned, adding them manually is the only way to get them. But beware:
-
-Although, please bear in mind any application that is found cheating, i.e. adding kudos artificially will have **all** the kudos manually removed with a blacklist rule in the AppStream builder.
-
-:::
-
 ### Content
 
 For the quick guidelines for the actual content (descriptions, screenshots), see the Appstream [docs](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).


### PR DESCRIPTION
This warning is talink about [Kudos](https://gitlab.gnome.org/GNOME/gnome-software/-/blob/8c340ba6922fd0ac9d88f9d5bcbf956b5a46022e/doc/kudos.md). But Kudos are not mentioned in the Docs (as far as I know, they are deprecated), so this Warning is placed in the OARS Section, which is confusing.