### PR TITLE
Quality guidelines: Formatting

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -3,7 +3,7 @@
 For the quick guidelines for the actual content (descriptions, screenshots), see the Appstream [docs](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).
 
 The following guidelines are optional, but recommended. We will likely promote apps that follow them in certain places.
-Therefor `must` is used in the following text, but it's not a requirement, it means that apps not following these guidelines will likely not be promoted.
+Therefore "must" is used in the following text, but it's not a requirement, it means that apps not following these guidelines will likely not be promoted.
 
 ## General
 
@@ -11,7 +11,7 @@ Therefor `must` is used in the following text, but it's not a requirement, it me
 
 Your app should not violate any trademarks. This includes the name, icon, and summary.
 
-For example, if your app is a Telegram client or web wrapper, it should not be called `Telegram for Linux` or use the official Telegram icon. Instead, it should have its own identity (e.g. `Paper Plane`, with a custom icon). If it's made clear that it's a third party client it can be ok to mention the original service (e.g. `Tally for Plausible`), but in most cases it should be avoided.
+For example, if your app is a Telegram client or web wrapper, it should not be called "Telegram for Linux" or use the official Telegram icon. Instead, it should have its own identity (e.g. "Paper Plane", with a custom icon). If it's made clear that it's a third party client it can be ok to mention the original service (e.g. "Tally for Plausible"), but in most cases it should be avoided.
 
 :::tip
 If you're not sure if your app violates any trademarks, feel free to ask us on [Matrix](https://matrix.to/#/#flathub:matrix.org).


### PR DESCRIPTION
Consistently use " instead of `