### PR TITLE
Quality guidelines: Minor update to summaries

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -65,7 +65,7 @@ The name should not have any weird formatting or punctuation. For example, it sh
 
 ### Not too long
 
-The summary should ideally be no longer than 35 characters, and must be shorter than 50 characters.
+The summary should ideally be between 10 and 25 characters, and no longer than 35 characters.
 
 ### Not technical
 


### PR DESCRIPTION
Someone on Mastodon pointed out that the previous wording made it seem like the range to shoot for is 35-50, while in reality summaries should be much shorter if at all possible. There's also no point in giving people 50 as an upper limit, because if they don't care enough to make it fit into 35 they won't care to make it fit into 50 either.