### PR TITLE
Fix broken link

### DIFF
--- a/docs/02-for-app-authors/05-submission.md
+++ b/docs/02-for-app-authors/05-submission.md
@@ -2,7 +2,7 @@
 
 ## How to submit an app
 
-App submissions are extremely welcome and the process is straightforward. Before submitting an app for inclusion on Flathub, please follow the [requirements](./requirements) to ensure that it is technically and legally compatible with the Flathub service. Once this has been done, you can submit the app for inclusion.
+App submissions are extremely welcome and the process is straightforward. Before submitting an app for inclusion on Flathub, please follow the [requirements](/docs/for-app-authors/requirements) to ensure that it is technically and legally compatible with the Flathub service. Once this has been done, you can submit the app for inclusion.
 
 Flathub is managed through a GitHub project, and app submissions take place as pull requests. To submit an app:
 


### PR DESCRIPTION
Sometimes, the requirements link breaks. I suspect that this happens because the web server rewrites urls to contain a trailing slash.

Current behavior: `https://docs.flathub.org/docs/for-app-authors/submission/` -> `https://docs.flathub.org/docs/for-app-authors/submission/requirements`
Intended behavior: `https://docs.flathub.org/docs/for-app-authors/submission` -> `https://docs.flathub.org/docs/for-app-authors/requirements`