### PR TITLE
authors/verification: mention how to verify an existing app

### DIFF
--- a/docs/02-for-app-authors/09-verification.md
+++ b/docs/02-for-app-authors/09-verification.md
@@ -10,4 +10,4 @@ First, [log in to Flathub](https://www.flathub.org/login). Go to the developer t
 
 ### I'd like to verify my app that someone else already published
 
-The first step is to gain ownership over  your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)
+The first step is to gain ownership over your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)

--- a/docs/02-for-app-authors/09-verification.md
+++ b/docs/02-for-app-authors/09-verification.md
@@ -7,3 +7,7 @@ Verification is a process by which Flathub can confirm that an app is published 
 ## I'm publishing an app on Flathub. How do I get it verified?
 
 First, [log in to Flathub](https://www.flathub.org/login). Go to the developer tab, if you're not already there. Click the "Developer Settings" button under the app you want to verify. At the top of the page, find the "Setup Verification" section. The instructions there will walk you through the verification process.
+
+### I'd like to verify my app that someone else already published
+
+The first step is to gain ownership over  your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)

--- a/docs/02-for-app-authors/09-verification.md
+++ b/docs/02-for-app-authors/09-verification.md
@@ -10,4 +10,4 @@ First, [log in to Flathub](https://www.flathub.org/login). Go to the developer t
 
 ### I'd like to verify my app that someone else already published
 
-The first step is to gain ownership over your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)
+The first step is to gain ownership over your app; see [Someone else has put my app on Flathub—what do I do?](submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)


### PR DESCRIPTION
This is useful documentation for when a third-party/community member has uploaded an app, and then the original developer wants to get it verified; we need to point them to how to gain ownership as a first step.