### PR TITLE
Clarify that app-id used in manifest should match with upstream

### DIFF
--- a/docs/02-for-app-authors/02-requirements.md
+++ b/docs/02-for-app-authors/02-requirements.md
@@ -20,6 +20,8 @@ using the `extra-data` source type.
 
 Each application should have a unique application ID, following the standard reverse-DNS schema. See [the Flatpak documentation](http://docs.flatpak.org/en/latest/conventions.html#application-ids) for more information on this. The Application ID should be a real URL of a domain that the app author has control over or where their app is hosted.
 
+The Application ID used in the manifest should match with the ID used by the application's upstream. This is necessary as flatpak by default only allows the application to own its own Application ID and its subnames in session-bus. If they don't match a `--own-name=<bus name>` might be required in `finish-args` section of the manifest.
+
 Ignoring this will lead to problems down the line, such as not being able to verify the app and receiving payments. It also decides, which verification methods will be available. For e.g. using `io.github.flathub.TestApp` would only allow for `Github` or `Website` verification.
 
 ## Repository layout


### PR DESCRIPTION
Hopefully prevents the situation with Kaiteki. The app id was `moe.craftplacer.kaiteki` 2 years ago https://github.com/Kaiteki-Fedi/Kaiteki/commit/356d9e865bb7b6a594ffb14bc5558e90e73f4929 but was submitted under a different app-id  `app.kaiteki.Kaiteki` leading to https://github.com/flathub/app.kaiteki.Kaiteki/issues/3

The submitters should ensure everything is consistent, it's hard to go look at source code of every application for possible mismatches while reviewing. 

This isn't mentioned in https://docs.flatpak.org/en/latest/conventions.html#application-ids or anywhere else. It's hinted at the session-bus policy section of the flatpak docs.

This isn't a hard requirement (hence "should") as applications like Firefox, Thunderbird etc. don't follow the dbus spec for naming the app id and always use `--own-name=<bus name>` in the manifest to grant access.