### PR TITLE
Tweak wording of app-id requirement and link to flatpak-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ This command starts a local development server and opens up a browser window. Mo
 
 You can access it on [http://localhost:3000](http://localhost:3000) then.
 
+If port 3000 is already in use and you see an error, use
+
+```
+$ yarn start --port PORT
+```
+
+to start it on a different port. See the [Docusaurus manual](https://docusaurus.io/docs/cli#docusaurus-cli-commands)
+for other arguments available.
+
 ### Build
 
 ```

--- a/docs/02-for-app-authors/02-requirements.md
+++ b/docs/02-for-app-authors/02-requirements.md
@@ -20,7 +20,7 @@ using the `extra-data` source type.
 
 Each application should have a unique application ID, following the standard reverse-DNS schema. See [the Flatpak documentation](http://docs.flatpak.org/en/latest/conventions.html#application-ids) for more information on this. The Application ID should be a real URL of a domain that the app author has control over or where their app is hosted.
 
-The Application ID used in the manifest should match with the ID used by the application's upstream. This is necessary as flatpak by default only allows the application to own its own Application ID and its subnames in session-bus. If they don't match a `--own-name=<bus name>` might be required in `finish-args` section of the manifest.
+The Application ID used in the manifest should match with the ID used by the application's upstream. This is necessary as flatpak provides a [filtered session-bus access](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#session-bus-policy-metadata) by default. If they don't match a `--own-name=<bus name>` might be required in `finish-args` section of the manifest.
 
 Ignoring this will lead to problems down the line, such as not being able to verify the app and receiving payments. It also decides, which verification methods will be available. For e.g. using `io.github.flathub.TestApp` would only allow for `Github` or `Website` verification.
 


### PR DESCRIPTION
Merge after https://github.com/flatpak/flatpak-docs/pull/415, the link should work after that is deployed