### PR TITLE
Quality guidelines: Add note about mixing fullscreen/windowed screenshots

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -200,7 +200,7 @@ Use the platform default configuration for all settings that affect screenshots,
 
 ### Include window shadow and rounded corners
 
-Screenshots must include the native toolkit shadow and rounding. App stores do not add a shadow after the fact and without one screenshots can look glitchy or have low contrast depending on the background. Apps that are always fullscreen (such as most games) are exempt from this.
+Screenshots must include the native toolkit shadow and rounding. App stores do not add a shadow after the fact and without one screenshots can look glitchy or have low contrast depending on the background. Apps that are always fullscreen (such as most games) are exempt from this, but in these cases all screenshots must be fullscreen. Do not use a mix of windowed and fullscreen screenshots.
 
 :::tip
 Don't maximize your app window when taking screenshots, since this will remove the shadow and rounding.


### PR DESCRIPTION
This is one way to address the issue, the other would be to add per-screenshot metadata. Maybe we should look into that longer-term.