### PR TITLE
Screenshot tag doesn't support xml:lang as per spec

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -179,7 +179,11 @@ Apps should have at least one screenshot in english. For medium complexity apps 
 Screenshots should be tagged with the language they are in. For example, if you have a screenshot of the app in german, tag it with `xml:lang="de"`.
 
 ```xml
- <screenshot xml:lang="de">https://www.example.com/de/app-name01.jpg</screenshot>
+  <screenshots>
+    <screenshot type="default">
+      <image xml:lang="de">https://www.example.com/de/app-name01.jpg</image>
+    </screenshot>
+  </screenshots>
 ```
 
 ### Just the app window


### PR DESCRIPTION
Only image or video does.

Also provide a full example

https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-screenshots